### PR TITLE
Default Safe Salt Nonce

### DIFF
--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -1,7 +1,7 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { UserOptions } from "../src";
+import { DEFAULT_SAFE_SALT_NONCE, UserOptions } from "../src";
 
 interface ScriptEnv {
   nearAccountId: string;
@@ -42,7 +42,7 @@ export async function loadArgs(): Promise<UserOptions> {
     .option("safeSaltNonce", {
       type: "string",
       description: "Salt nonce used for the Safe deployment",
-      default: "0",
+      default: DEFAULT_SAFE_SALT_NONCE,
     })
     .option("mpcContractId", {
       type: "string",

--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -1,9 +1,9 @@
 import dotenv from "dotenv";
 import { ethers } from "ethers";
-import { isAddress } from "viem";
+import { decodeFunctionData, isAddress, parseAbi, toHex } from "viem";
 
 import { loadArgs, loadEnv } from "./cli";
-import { NearSafe } from "../src";
+import { DEFAULT_SAFE_SALT_NONCE, NearSafe } from "../src";
 
 dotenv.config();
 
@@ -18,6 +18,7 @@ async function main(): Promise<void> {
     mpcContractId,
     pimlicoKey,
     privateKey: nearAccountPrivateKey,
+    safeSaltNonce: DEFAULT_SAFE_SALT_NONCE,
   });
   const deployed = await txManager.safeDeployed(chainId);
   console.log("Safe Deployed:", deployed);

--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -1,6 +1,6 @@
 import dotenv from "dotenv";
 import { ethers } from "ethers";
-import { decodeFunctionData, isAddress, parseAbi, toHex } from "viem";
+import { isAddress } from "viem";
 
 import { loadArgs, loadEnv } from "./cli";
 import { DEFAULT_SAFE_SALT_NONCE, NearSafe } from "../src";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "description": "An SDK for controlling Ethereum Smart Accounts via ERC4337 from a Near Account.",
-  "author": "@bh2smith",
+  "author": "bh2smith",
   "repository": {
     "type": "git",
     "url": "https://github.com/BitteProtocol/near-safe"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "description": "An SDK for controlling Ethereum Smart Accounts via ERC4337 from a Near Account.",
-  "author": "bh2smith",
+  "author": "@bh2smith",
   "repository": {
     "type": "git",
     "url": "https://github.com/BitteProtocol/near-safe"
@@ -44,7 +44,7 @@
     "@safe-global/safe-gateway-typescript-sdk": "^3.22.2",
     "ethers-multisend": "^3.1.0",
     "near-api-js": "^5.0.0",
-    "near-ca": "^0.5.7",
+    "near-ca": "^0.5.8",
     "semver": "^7.6.3",
     "viem": "^2.16.5"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { saltNonceFromMessage } from "./util";
 
+// 44996514629493770112085868524049986283670269803674596648610276180743582360860
 export const DEFAULT_SAFE_SALT_NONCE = saltNonceFromMessage(
   "bitteprotocol/near-safe"
 );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+import { saltNonceFromMessage } from "./util";
+
+export const DEFAULT_SAFE_SALT_NONCE = saltNonceFromMessage(
+  "bitteprotocol/near-safe"
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./near-safe";
 export * from "./types";
 export * from "./util";
+export * from "./constants";
 
 export { Network, BaseTx, SignRequestData, populateTx } from "near-ca";

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -57,7 +57,6 @@ export class SafeContractSuite {
         [keccak256(setup), BigInt(saltNonce || "0")]
       )
     );
-    console.log("SALT", salt);
 
     // abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(_singleton)));
     // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L29

--- a/src/lib/safe.ts
+++ b/src/lib/safe.ts
@@ -57,6 +57,7 @@ export class SafeContractSuite {
         [keccak256(setup), BigInt(saltNonce || "0")]
       )
     );
+    console.log("SALT", salt);
 
     // abi.encodePacked(type(SafeProxy).creationCode, uint256(uint160(_singleton)));
     // cf: https://github.com/safe-global/safe-smart-account/blob/499b17ad0191b575fcadc5cb5b8e3faeae5391ae/contracts/proxies/SafeProxyFactory.sol#L29

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -9,6 +9,7 @@ import {
   EthSignParams,
   toPayload,
   PersonalSignParams,
+  mockAdapter,
 } from "near-ca";
 import {
   Address,
@@ -37,13 +38,16 @@ import {
   metaTransactionsFromRequest,
   packSignature,
 } from "./util";
+import { DEFAULT_SAFE_SALT_NONCE } from "./constants";
 
 export interface NearSafeConfig {
+  // Adapter Config:
   accountId: string;
   mpcContractId: string;
-  pimlicoKey: string;
   nearConfig?: NearConfig;
   privateKey?: string;
+  // Safe Config:
+  pimlicoKey: string;
   safeSaltNonce?: string;
 }
 
@@ -64,6 +68,7 @@ export class NearSafe {
    */
   static async create(config: NearSafeConfig): Promise<NearSafe> {
     const { pimlicoKey, safeSaltNonce } = config;
+    // const nearAdapter = await mockAdapter();
     const nearAdapter = await setupAdapter({ ...config });
     const safePack = new SafeContractSuite();
 
@@ -81,7 +86,7 @@ export class NearSafe {
       pimlicoKey,
       setup,
       safeAddress,
-      safeSaltNonce || "0"
+      safeSaltNonce || DEFAULT_SAFE_SALT_NONCE
     );
   }
 
@@ -127,7 +132,7 @@ export class NearSafe {
    * @returns {string} - The contract ID of the MPC contract.
    */
   get mpcContractId(): string {
-    return this.nearAdapter.mpcContract.contract.contractId;
+    return this.nearAdapter.mpcContract.accountId();
   }
 
   /**

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -9,7 +9,6 @@ import {
   EthSignParams,
   toPayload,
   PersonalSignParams,
-  mockAdapter,
 } from "near-ca";
 import {
   Address,
@@ -20,6 +19,7 @@ import {
   serializeSignature,
 } from "viem";
 
+import { DEFAULT_SAFE_SALT_NONCE } from "./constants";
 import { Erc4337Bundler } from "./lib/bundler";
 import { encodeMulti, isMultisendTx } from "./lib/multisend";
 import { SafeContractSuite } from "./lib/safe";
@@ -38,7 +38,6 @@ import {
   metaTransactionsFromRequest,
   packSignature,
 } from "./util";
-import { DEFAULT_SAFE_SALT_NONCE } from "./constants";
 
 export interface NearSafeConfig {
   // Adapter Config:

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,8 @@ import {
   isHex,
   parseTransaction,
   zeroAddress,
+  toBytes,
+  keccak256,
 } from "viem";
 
 import { PaymasterData, MetaTransaction } from "./types";
@@ -83,4 +85,14 @@ export function metaTransactionsFromRequest(
     value: tx.value || "0x00",
     data: tx.data || "0x",
   }));
+}
+
+export function saltNonceFromMessage(input: string): string {
+  // Convert the string to bytes (UTF-8 encoding)
+  const inputBytes = toBytes(input);
+  // Compute the keccak256 hash of the input bytes
+  const hash = keccak256(inputBytes);
+  // Convert the resulting hash (which is in hex) to a BigInt
+  const uint256Value = BigInt(hash);
+  return uint256Value.toString();
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,10 +89,8 @@ export function metaTransactionsFromRequest(
 
 export function saltNonceFromMessage(input: string): string {
   // Convert the string to bytes (UTF-8 encoding)
-  const inputBytes = toBytes(input);
   // Compute the keccak256 hash of the input bytes
-  const hash = keccak256(inputBytes);
   // Convert the resulting hash (which is in hex) to a BigInt
-  const uint256Value = BigInt(hash);
-  return uint256Value.toString();
+  // Return string for readability and transport.
+  return BigInt(keccak256(toBytes(input))).toString();
 }

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { zeroAddress } from "viem";
 
-import { PaymasterData } from "../../src";
+import { DEFAULT_SAFE_SALT_NONCE, PaymasterData } from "../../src";
 import {
   PLACEHOLDER_SIG,
   containsValue,
@@ -9,6 +9,7 @@ import {
   packGas,
   packPaymasterData,
   packSignature,
+  saltNonceFromMessage,
 } from "../../src/util";
 
 describe("Utility Functions (mostly byte packing)", () => {
@@ -74,5 +75,11 @@ describe("Utility Functions (mostly byte packing)", () => {
     expect(
       await isContract("0x9008D19f58AAbD9eD0D60971565AA8510560ab41", chainId)
     ).toBe(true);
+  });
+  it("saltNonceFromMessage", async () => {
+    expect(saltNonceFromMessage("bitteprotocol/near-safe")).toBe(
+      DEFAULT_SAFE_SALT_NONCE
+    );
+    // console.log("DEFAULT_SAFE_SALT_NONCE", DEFAULT_SAFE_SALT_NONCE);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4405,10 +4405,10 @@ near-api-js@^5.0.0:
     near-abi "0.1.1"
     node-fetch "2.6.7"
 
-near-ca@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.5.7.tgz#e1b2c311514fa6b90eced3750359aeb2d4f4b06f"
-  integrity sha512-63zZXJj2PXFld5KiD7M8kAQ22zSFbz8bD9BM4+pg8ZoITC47gE5xiVPD5oMfJiiyCFH0PsQOZdP4TtJG+a/HAQ==
+near-ca@^0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.5.8.tgz#c4f964a80e7dab83c9ec5b80d4e0bd33a32e574e"
+  integrity sha512-oTiDn9BWpbSd02tJEO7JORGVq5rJmLQbBXhvb9OR7F5Kw9wg/F/UqIDm9eCAE2/znTD97Ph4Thhi9m2kvYzmew==
   dependencies:
     "@walletconnect/web3wallet" "^1.13.0"
     elliptic "^6.5.6"


### PR DESCRIPTION
This PR opens up the setup config for end users to pass their own, while changing the fallback to our own custom value. This acts like a Domain Separator and will allow us to query wallet deployed from this library (if users choose not to alter it). 