### PR TITLE
Ensure Sponsorship Policy on Paymaster Requests

### DIFF
--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -28,16 +28,14 @@ export async function loadEnv(): Promise<ScriptEnv> {
 
 export async function loadArgs(): Promise<UserOptions> {
   return yargs(hideBin(process.argv))
-    .option("usePaymaster", {
-      type: "boolean",
+    .option("sponsorshipPolicy", {
+      type: "string",
       description: "Have transaction sponsored by paymaster service",
-      default: false,
     })
     .option("recoveryAddress", {
       type: "string",
       description:
         "Recovery address to be attached as owner of the Safe (immediately adter deployment)",
-      default: undefined,
     })
     .option("safeSaltNonce", {
       type: "string",

--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -10,7 +10,7 @@ dotenv.config();
 async function main(): Promise<void> {
   const [
     { pimlicoKey, nearAccountId, nearAccountPrivateKey },
-    { mpcContractId, recoveryAddress, usePaymaster },
+    { mpcContractId, recoveryAddress, sponsorshipPolicy },
   ] = await Promise.all([loadEnv(), loadArgs()]);
   const chainId = 11155111;
   const txManager = await NearSafe.create({
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
   const unsignedUserOp = await txManager.buildTransaction({
     chainId,
     transactions,
-    usePaymaster,
+    sponsorshipPolicy,
   });
   console.log("Unsigned UserOp", unsignedUserOp);
   const safeOpHash = await txManager.opHash(chainId, unsignedUserOp);
@@ -53,11 +53,13 @@ async function main(): Promise<void> {
   // TODO: Evaluate gas cost (in ETH)
   const gasCost = ethers.parseEther("0.01");
   // Whenever not using paymaster, or on value transfer, the Safe must be funded.
-  const sufficientFunded = await txManager.sufficientlyFunded(
-    chainId,
-    transactions,
-    usePaymaster ? 0n : gasCost
-  );
+  const sufficientFunded =
+    sponsorshipPolicy ||
+    (await txManager.sufficientlyFunded(
+      chainId,
+      transactions,
+      !!sponsorshipPolicy ? 0n : gasCost
+    ));
   if (!sufficientFunded) {
     console.warn(
       `Safe ${txManager.address} insufficiently funded to perform this transaction. Exiting...`

--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -53,13 +53,11 @@ async function main(): Promise<void> {
   // TODO: Evaluate gas cost (in ETH)
   const gasCost = ethers.parseEther("0.01");
   // Whenever not using paymaster, or on value transfer, the Safe must be funded.
-  const sufficientFunded =
-    sponsorshipPolicy ||
-    (await txManager.sufficientlyFunded(
-      chainId,
-      transactions,
-      !!sponsorshipPolicy ? 0n : gasCost
-    ));
+  const sufficientFunded = await txManager.sufficientlyFunded(
+    chainId,
+    transactions,
+    !!sponsorshipPolicy ? 0n : gasCost
+  );
   if (!sufficientFunded) {
     console.warn(
       `Safe ${txManager.address} insufficiently funded to perform this transaction. Exiting...`

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -24,10 +24,12 @@ function bundlerUrl(chainId: number, apikey: string): string {
   return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${apikey}`;
 }
 
+type SponsorshipPolicy = { sponsorshipPolicyId: string };
+
 type BundlerRpcSchema = [
   {
     Method: "pm_sponsorUserOperation";
-    Parameters: [UnsignedUserOperation, Address];
+    Parameters: [UnsignedUserOperation, Address, SponsorshipPolicy];
     ReturnType: PaymasterData;
   },
   {
@@ -65,11 +67,11 @@ export class Erc4337Bundler {
 
   async getPaymasterData(
     rawUserOp: UnsignedUserOperation,
-    usePaymaster: boolean,
-    safeNotDeployed: boolean
+    safeNotDeployed: boolean,
+    sponsorshipPolicy?: string
   ): Promise<PaymasterData> {
     // TODO: Keep this option out of the bundler
-    if (usePaymaster) {
+    if (sponsorshipPolicy) {
       console.log("Requesting paymaster data...");
       return handleRequest<PaymasterData>(() =>
         this.client.request({
@@ -77,6 +79,7 @@ export class Erc4337Bundler {
           params: [
             { ...rawUserOp, signature: PLACEHOLDER_SIG },
             this.entryPointAddress,
+            { sponsorshipPolicyId: sponsorshipPolicy },
           ],
         })
       );

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -29,6 +29,8 @@ type SponsorshipPolicy = { sponsorshipPolicyId: string };
 type BundlerRpcSchema = [
   {
     Method: "pm_sponsorUserOperation";
+    // TODO(bh2smith): Add possiblity to not supply policy:
+    // [UnsignedUserOperation, Address]
     Parameters: [UnsignedUserOperation, Address, SponsorshipPolicy];
     ReturnType: PaymasterData;
   },

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -158,9 +158,9 @@ export class NearSafe {
   async buildTransaction(args: {
     chainId: number;
     transactions: MetaTransaction[];
-    usePaymaster: boolean;
+    sponsorshipPolicy?: string;
   }): Promise<UserOperation> {
-    const { transactions, usePaymaster, chainId } = args;
+    const { transactions, sponsorshipPolicy, chainId } = args;
     if (transactions.length === 0) {
       throw new Error("Empty transaction set!");
     }
@@ -189,8 +189,8 @@ export class NearSafe {
 
     const paymasterData = await bundler.getPaymasterData(
       rawUserOp,
-      usePaymaster,
-      !safeDeployed
+      !safeDeployed,
+      sponsorshipPolicy
     );
 
     const unsignedUserOp = { ...rawUserOp, ...paymasterData };
@@ -228,11 +228,11 @@ export class NearSafe {
    */
   async encodeSignRequest(
     signRequest: SignRequestData,
-    usePaymaster: boolean
+    sponsorshipPolicy?: string
   ): Promise<EncodedTxData> {
     const { payload, evmMessage, hash } = await this.requestRouter(
       signRequest,
-      usePaymaster
+      sponsorshipPolicy
     );
     return {
       nearPayload: await this.nearAdapter.mpcContract.encodeSignatureRequestTx({
@@ -420,7 +420,7 @@ export class NearSafe {
    */
   async requestRouter(
     { method, chainId, params }: SignRequestData,
-    usePaymaster: boolean
+    sponsorshipPolicy?: string
   ): Promise<{
     evmMessage: string;
     payload: number[];
@@ -460,7 +460,7 @@ export class NearSafe {
         const userOp = await this.buildTransaction({
           chainId,
           transactions,
-          usePaymaster,
+          ...(sponsorshipPolicy ? { sponsorshipPolicy } : {}),
         });
         const opHash = await this.opHash(chainId, userOp);
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface PaymasterData {
  */
 export interface UserOptions {
   /** Whether to use a paymaster for gas fee coverage. */
-  usePaymaster: boolean;
+  sponsorshipPolicy?: string;
   /** The unique nonce used to differentiate multiple Safe setups. */
   safeSaltNonce: string;
   /** The NEAR contract ID for the MPC contract. */


### PR DESCRIPTION
I have disabled the free-for-all sponsoring. Now one must provide a `sponsorshipPolicy` at request time.

Update: `Pimlico now has a setting to enable testnet sponsorship on policies.`

I am not entirely happy with the solution here, but its an ok start. Maybe it could be simplified... Specifically reverted back to the first commit. will try.