### PR TITLE
Decode personal_sign Messages for UI

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,8 @@ export interface DecodedMultisend {
   costEstimate: string;
   /** The list of meta-transactions included in the multisend. */
   transactions: MetaTransaction[];
+  /** Raw Message to sign if no transactions present. */
+  message?: string;
 }
 
 /**

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -68,4 +68,43 @@ describe("Near Safe Requests", () => {
       })
     ).resolves.not.toThrow();
   });
+
+  it("adapter: decodeTxData", async () => {
+    // setup:
+    const chainId = 11155111;
+    const expectedMessage =
+      "Welcome to OpenSea!\n" +
+      "\n" +
+      "Click to sign in and accept the OpenSea Terms of Service (https://opensea.io/tos) and Privacy Policy (https://opensea.io/privacy).\n" +
+      "\n" +
+      "This request will not trigger a blockchain transaction or cost any gas fees.\n" +
+      "\n" +
+      "Wallet address:\n" +
+      "0xf057e37024abe7e6bc04fb4f00978613b5ca0241\n" +
+      "\n" +
+      "Nonce:\n" +
+      "aca09a1c-a800-4d71-98ed-547f7c59370c";
+
+    const signRequest = await adapter.encodeSignRequest({
+      method: "personal_sign",
+      chainId,
+      params: [
+        "0x57656c636f6d6520746f204f70656e536561210a0a436c69636b20746f207369676e20696e20616e642061636365707420746865204f70656e536561205465726d73206f662053657276696365202868747470733a2f2f6f70656e7365612e696f2f746f732920616e64205072697661637920506f6c696379202868747470733a2f2f6f70656e7365612e696f2f70726976616379292e0a0a5468697320726571756573742077696c6c206e6f742074726967676572206120626c6f636b636861696e207472616e73616374696f6e206f7220636f737420616e792067617320666565732e0a0a57616c6c657420616464726573733a0a3078663035376533373032346162653765366263303466623466303039373836313362356361303234310a0a4e6f6e63653a0a61636130396131632d613830302d346437312d393865642d353437663763353933373063",
+        "0xf057e37024abe7e6bc04fb4f00978613b5ca0241",
+      ],
+    });
+
+    expect(signRequest.evmData).toStrictEqual({
+      chainId,
+      hash: "0xb3a14f9bd21518d7da23dba01ddf7c7ef45795ca1515f1b41b6f3455c862e22d",
+      data: expectedMessage,
+    });
+
+    expect(adapter.decodeTxData(signRequest.evmData)).toStrictEqual({
+      chainId: 11155111,
+      costEstimate: "0",
+      transactions: [],
+      message: expectedMessage,
+    });
+  });
 });


### PR DESCRIPTION
The UI wants to display other types of signature requests..


Pro Tip (@Jxnis) you can check if `decoded.message !== undefined` --> Show the message instead (and chain Id). and probably the message hash...

note sure if this is the best approach, but it satisfies the criteria for now.