### PR TITLE
Resolving JSON parse Error on decoding

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -48,8 +48,16 @@ export function decodeTxData({
         message: data,
       };
     } else {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`decodeTxData: Unexpected error - ${message}`);
+      // TODO: This shouldn't happen anymore and can probably be reverted.
+      // We keep it here now, because near-ca might not have adapted its router.
+      console.warn("Failed UserOp Parsing, try TypedData Parsing", error);
+      try {
+        const typedData: EIP712TypedData = JSON.parse(data);
+        return decodeTypedData(chainId, typedData);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`decodeTxData: Unexpected error - ${message}`);
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./near-safe";
 export * from "./types";
 export * from "./util";
 export * from "./constants";
+export * from "./decode";
 
 export {
   Network,
@@ -11,4 +12,5 @@ export {
   NetworkFields,
   signatureFromOutcome,
   signatureFromTxHash,
+  requestRouter as mpcRequestRouter,
 } from "near-ca";

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -420,6 +420,7 @@ export class NearSafe {
 
     // Early return with eoaEncoding if `from` is not the Safe
     if (!this.encodeForSafe(fromAddresses[0])) {
+      // TODO: near-ca needs to update this for typed data like we did.
       return mpcRequestRouter({ method, chainId, params });
     }
 
@@ -433,7 +434,17 @@ export class NearSafe {
     // We should either confirm they agree or ignore one of the two.
     switch (method) {
       case "eth_signTypedData":
-      case "eth_signTypedData_v4":
+      case "eth_signTypedData_v4": {
+        const [_, typedDataString] = params as EthSignParams;
+        const message = decodeSafeMessage(
+          JSON.parse(typedDataString),
+          safeInfo
+        );
+        return {
+          evmMessage: JSON.parse(typedDataString),
+          hashToSign: message.safeMessageHash,
+        };
+      }
       case "eth_sign": {
         const [_, messageOrData] = params as EthSignParams;
         const message = decodeSafeMessage(messageOrData, safeInfo);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -79,7 +79,7 @@ describe("Near Safe Requests", () => {
       params: [adapter.mpcAddress, typedDataString],
     });
 
-    expect(() => decodeTxData({ ...evmData }));
+    expect(() => decodeTxData({ ...evmData })).not.toThrow();
 
     expect(evmData).toStrictEqual({
       chainId: 11155111,

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import { isHex } from "viem";
 
 import { DEFAULT_SAFE_SALT_NONCE, NearSafe } from "../src";
+import { decodeTxData } from "../src/decode";
 
 dotenv.config();
 
@@ -53,7 +54,7 @@ describe("Near Safe Requests", () => {
     await expect(adapter.policyForChainId(100)).resolves.not.toThrow();
   });
 
-  it("adapter: encodeEvmTx", async () => {
+  it.only("adapter: encodeEvmTx", async () => {
     await expect(
       adapter.encodeSignRequest({
         method: "eth_sendTransaction",
@@ -77,6 +78,8 @@ describe("Near Safe Requests", () => {
       method: "eth_signTypedData_v4",
       params: [adapter.mpcAddress, typedDataString],
     });
+
+    expect(() => decodeTxData({ ...evmData }));
 
     expect(evmData).toStrictEqual({
       chainId: 11155111,


### PR DESCRIPTION
Error: decodeTxData: Unexpected error - can't convert undefined to BigInt

This was happening because `signTypedData` requests are also stringified JSONs and we assume, naively, that they would be UserOperation. left some TODOs.