### PR TITLE
Dont expose ethers-multisend

### DIFF
--- a/src/decode/index.ts
+++ b/src/decode/index.ts
@@ -1,0 +1,58 @@
+import { EIP712TypedData } from "near-ca";
+
+import { isRlpHex, isTransactionSerializable } from "../lib/safe-message";
+import { DecodedTxData, SafeEncodedSignRequest, UserOperation } from "../types";
+import {
+  decodeRlpHex,
+  decodeTransactionSerializable,
+  decodeTypedData,
+  decodeUserOperation,
+} from "./util";
+
+/**
+ * Decodes transaction data for a given EVM transaction and extracts relevant details.
+ *
+ * @param {EvmTransactionData} data - The raw transaction data to be decoded.
+ * @returns {DecodedTxData} - An object containing the chain ID, estimated cost, and a list of decoded meta-transactions.
+ */
+export function decodeTxData({
+  evmMessage,
+  chainId,
+}: Omit<SafeEncodedSignRequest, "hashToSign">): DecodedTxData {
+  const data = evmMessage;
+  if (isRlpHex(evmMessage)) {
+    return decodeRlpHex(chainId, evmMessage);
+  }
+  if (isTransactionSerializable(data)) {
+    return decodeTransactionSerializable(chainId, data);
+  }
+  if (typeof data !== "string") {
+    return decodeTypedData(chainId, data);
+  }
+  try {
+    // Stringified UserOperation.
+    const userOp: UserOperation = JSON.parse(data);
+    return decodeUserOperation(chainId, userOp);
+  } catch (error: unknown) {
+    if (error instanceof SyntaxError) {
+      // Raw message string.
+      return {
+        chainId,
+        costEstimate: "0",
+        transactions: [],
+        message: data,
+      };
+    } else {
+      // TODO: This shouldn't happen anymore and can probably be reverted.
+      // We keep it here now, because near-ca might not have adapted its router.
+      console.warn("Failed UserOp Parsing, try TypedData Parsing", error);
+      try {
+        const typedData: EIP712TypedData = JSON.parse(data);
+        return decodeTypedData(chainId, typedData);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`decodeTxData: Unexpected error - ${message}`);
+      }
+    }
+  }
+}

--- a/src/decode/util.ts
+++ b/src/decode/util.ts
@@ -9,58 +9,9 @@ import {
   TransactionSerializable,
 } from "viem";
 
-import { SAFE_DEPLOYMENTS } from "./_gen/deployments";
-import { isMultisendTx } from "./lib/multisend";
-import { isRlpHex, isTransactionSerializable } from "./lib/safe-message";
-import { DecodedTxData, SafeEncodedSignRequest, UserOperation } from "./types";
-
-/**
- * Decodes transaction data for a given EVM transaction and extracts relevant details.
- *
- * @param {EvmTransactionData} data - The raw transaction data to be decoded.
- * @returns {DecodedTxData} - An object containing the chain ID, estimated cost, and a list of decoded meta-transactions.
- */
-export function decodeTxData({
-  evmMessage,
-  chainId,
-}: Omit<SafeEncodedSignRequest, "hashToSign">): DecodedTxData {
-  const data = evmMessage;
-  if (isRlpHex(evmMessage)) {
-    return decodeRlpHex(chainId, evmMessage);
-  }
-  if (isTransactionSerializable(data)) {
-    return decodeTransactionSerializable(chainId, data);
-  }
-  if (typeof data !== "string") {
-    return decodeTypedData(chainId, data);
-  }
-  try {
-    // Stringified UserOperation.
-    const userOp: UserOperation = JSON.parse(data);
-    return decodeUserOperation(chainId, userOp);
-  } catch (error: unknown) {
-    if (error instanceof SyntaxError) {
-      // Raw message string.
-      return {
-        chainId,
-        costEstimate: "0",
-        transactions: [],
-        message: data,
-      };
-    } else {
-      // TODO: This shouldn't happen anymore and can probably be reverted.
-      // We keep it here now, because near-ca might not have adapted its router.
-      console.warn("Failed UserOp Parsing, try TypedData Parsing", error);
-      try {
-        const typedData: EIP712TypedData = JSON.parse(data);
-        return decodeTypedData(chainId, typedData);
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`decodeTxData: Unexpected error - ${message}`);
-      }
-    }
-  }
-}
+import { SAFE_DEPLOYMENTS } from "../_gen/deployments";
+import { isMultisendTx } from "../lib/multisend";
+import { DecodedTxData, UserOperation } from "../types";
 
 export function decodeTransactionSerializable(
   chainId: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export * from "./near-safe";
 export * from "./types";
 export * from "./util";
 export * from "./constants";
-export * from "./decode";
+export { decodeTxData } from "./decode";
 export * from "./lib/safe-message";
 
 export {

--- a/tests/unit/decode.spec.ts
+++ b/tests/unit/decode.spec.ts
@@ -1,14 +1,13 @@
 import { EIP712TypedData } from "near-ca";
 import { TransactionSerializableEIP1559 } from "viem";
 
-import { SafeEncodedSignRequest, UserOperation } from "../../src";
+import { SafeEncodedSignRequest, UserOperation, decodeTxData } from "../../src";
 import {
   decodeRlpHex,
   decodeTransactionSerializable,
-  decodeTxData,
   decodeTypedData,
   decodeUserOperation,
-} from "../../src/decode";
+} from "../../src/decode/util";
 
 const chainId = 11155111;
 describe("decoding functions", () => {


### PR DESCRIPTION
This issue came up when we exported everything for decodeTxData. Now we only selectively export so that ethers-multisend is not included.


```
./node_modules/.pnpm/ethers-multisend@3.1.0/node_modules/ethers-multisend/build/esm/index.js + 43 modules
Cannot get final name for export 'BigNumber' of ./node_modules/.pnpm/@ethersproject+bignumber@5.7.0/node_modules/@ethersproject/bignumber/lib.esm/index.js
```
