### PR TITLE
*Breaking: Use MpcConfig

### DIFF
--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -1,4 +1,3 @@
-import { NearConfig } from "near-api-js/lib/near";
 import {
   NearEthAdapter,
   setupAdapter,
@@ -9,6 +8,7 @@ import {
   requestRouter as mpcRequestRouter,
   EncodedSignRequest,
   EthTransactionParams,
+  SetupConfig as MpcConfig,
 } from "near-ca";
 import { Address, Hash, Hex, zeroAddress } from "viem";
 
@@ -33,11 +33,7 @@ import {
 } from "./util";
 
 export interface NearSafeConfig {
-  // Adapter Config:
-  accountId: string;
-  mpcContractId: string;
-  nearConfig?: NearConfig;
-  privateKey?: string;
+  mpc: MpcConfig;
   // Safe Config:
   pimlicoKey: string;
   safeSaltNonce?: string;
@@ -63,7 +59,7 @@ export class NearSafe {
     const safeSaltNonce = config.safeSaltNonce || DEFAULT_SAFE_SALT_NONCE;
 
     // const nearAdapter = await mockAdapter();
-    const nearAdapter = await setupAdapter({ ...config });
+    const nearAdapter = await setupAdapter(config.mpc);
     const safePack = new SafeContractSuite();
 
     const setup = safePack.getSetup([nearAdapter.address]);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -11,8 +11,10 @@ describe("Near Safe Requests", () => {
   beforeAll(async () => {
     // Initialize the NearSafe adapter once before all tests
     adapter = await NearSafe.create({
-      accountId: "neareth-dev.testnet",
-      mpcContractId: "v1.signer-prod.testnet",
+      mpc: {
+        accountId: "neareth-dev.testnet",
+        mpcContractId: "v1.signer-prod.testnet",
+      },
       pimlicoKey: process.env.PIMLICO_KEY!,
       safeSaltNonce: DEFAULT_SAFE_SALT_NONCE,
     });


### PR DESCRIPTION
Previously we didn't have an option for the user to specify the MPC derivationPath. By adopting the MPC SetupConfig, this is now available.

Note that this is a breaking change.