### PR TITLE
Proper Gas Estimation for Unsponsored UserOps

### DIFF
--- a/examples/send-tx.ts
+++ b/examples/send-tx.ts
@@ -1,9 +1,14 @@
 import dotenv from "dotenv";
 import { ethers } from "ethers";
-import { isAddress } from "viem";
+import { formatEther, isAddress } from "viem";
 
 import { loadArgs, loadEnv } from "./cli";
-import { DEFAULT_SAFE_SALT_NONCE, NearSafe, Network } from "../src";
+import {
+  DEFAULT_SAFE_SALT_NONCE,
+  NearSafe,
+  Network,
+  userOpTransactionCost,
+} from "../src";
 
 dotenv.config();
 
@@ -48,8 +53,8 @@ async function main(): Promise<void> {
   const safeOpHash = await txManager.opHash(chainId, unsignedUserOp);
   console.log("Safe Op Hash", safeOpHash);
 
-  // TODO: Evaluate gas cost (in ETH)
-  const gasCost = ethers.parseEther("0.01");
+  const gasCost = userOpTransactionCost(unsignedUserOp);
+  console.log("Estimated gas cost", formatEther(gasCost));
   // Whenever not using paymaster, or on value transfer, the Safe must be funded.
   const sufficientFunded = await txManager.sufficientlyFunded(
     chainId,

--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -182,15 +182,6 @@ async function handleRequest<T>(clientMethod: () => Promise<T>): Promise<T> {
   }
 }
 
-// // TODO(bh2smith) Should probably get reasonable estimates here:
-// const defaultPaymasterData = (safeNotDeployed: boolean): PaymasterData => {
-//   return {
-//     verificationGasLimit: toHex(safeNotDeployed ? 500000 : 100000),
-//     callGasLimit: toHex(100000),
-//     preVerificationGas: toHex(100000),
-//   };
-// };
-
 export function stripApiKey(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.replace(/(apikey=)[^\s&]+/, "$1***");

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -178,7 +178,6 @@ export class NearSafe {
 
     const paymasterData = await bundler.getPaymasterData(
       rawUserOp,
-      !safeDeployed,
       sponsorshipPolicy
     );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,6 @@ export interface UserOperation extends UnsignedUserOperation, PaymasterData {
   /** Optional signature for the user operation. */
   signature?: Hex;
 }
-// TODO(bh2smith): deduplicate the GasData fields between UserOperation and PaymasterData
-// {verificationGasLimit, callGasLimit, preVerificationGas}
 
 /**
  * Represents additional paymaster-related data for a user operation.

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,13 +55,7 @@ export interface UnsignedUserOperation {
 /**
  * Supported representation of a user operation for EntryPoint version 0.7, including gas limits and signature.
  */
-export interface UserOperation extends UnsignedUserOperation {
-  /** The gas limit for verification of the operation. */
-  verificationGasLimit: Hex;
-  /** The gas limit for the execution of the operation call. */
-  callGasLimit: Hex;
-  /** The gas used before verification begins. */
-  preVerificationGas: Hex;
+export interface UserOperation extends UnsignedUserOperation, PaymasterData {
   /** Optional signature for the user operation. */
   signature?: Hex;
 }
@@ -71,11 +65,14 @@ export interface UserOperation extends UnsignedUserOperation {
 /**
  * Represents additional paymaster-related data for a user operation.
  */
-export interface PaymasterData {
+export interface PaymasterData extends UserOperationGas {
   /** Optional paymaster address responsible for covering gas costs. */
   paymaster?: Address;
   /** Optional additional data required by the paymaster. */
   paymasterData?: Hex;
+}
+
+export interface UserOperationGas {
   /** The gas limit for paymaster verification. */
   paymasterVerificationGasLimit?: Hex;
   /** The gas limit for paymaster post-operation execution. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,7 +68,7 @@ export async function isContract(
 }
 
 export function getClient(chainId: number): PublicClient {
-  // TODO(bh2smith)
+  // TODO(bh2smith): Update defailt client URL in viem for sepolia.
   if (chainId === 11155111) {
     return createPublicClient({ transport: http(DEFAULT_SETUP_RPC) });
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,7 +23,7 @@ import {
 } from "viem";
 
 import { DEFAULT_SETUP_RPC } from "./constants";
-import { PaymasterData, MetaTransaction } from "./types";
+import { PaymasterData, MetaTransaction, UserOperation } from "./types";
 
 export const PLACEHOLDER_SIG = encodePacked(["uint48", "uint48"], [0, 0]);
 
@@ -200,4 +200,34 @@ export function assertUnique<T>(
   if (uniqueValues.size > 1) {
     throw new Error(errorMessage);
   }
+}
+
+export function userOpTransactionCost(userOp: UserOperation): bigint {
+  // Convert values from hex to decimal
+  const preVerificationGas = BigInt(userOp.preVerificationGas);
+  const verificationGasLimit = BigInt(userOp.verificationGasLimit);
+  const callGasLimit = BigInt(userOp.callGasLimit);
+  const paymasterVerificationGasLimit = BigInt(
+    userOp.paymasterVerificationGasLimit || "0x0"
+  );
+  const paymasterPostOpGasLimit = BigInt(
+    userOp.paymasterPostOpGasLimit || "0x0"
+  );
+
+  // Sum total gas
+  const totalGasUsed =
+    preVerificationGas +
+    verificationGasLimit +
+    callGasLimit +
+    paymasterVerificationGasLimit +
+    paymasterPostOpGasLimit;
+
+  // Convert maxFeePerGas from hex to decimal
+  const maxFeePerGas = BigInt(userOp.maxFeePerGas);
+
+  // Calculate total cost in wei
+  const totalCostInWei = totalGasUsed * maxFeePerGas;
+
+  // Convert to Ether for a human-readable value
+  return totalCostInWei;
 }


### PR DESCRIPTION
Resolving a long outstanding TODO where we had hard-coded the gas estimations for non-sponsored user ops. This resulted in paying too much gas! On mainnet this was uncomfortable.