### PR TITLE
SignRequest: Determine Broadcast Target

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./constants";
 export * from "./decode";
 export * from "./lib/safe-message";
 
+// TODO: Improve re-exports...
 export {
   Network,
   BaseTx,
@@ -15,4 +16,5 @@ export {
   signatureFromTxHash,
   requestRouter as mpcRequestRouter,
   EthTransactionParams,
+  isRlpHex,
 } from "near-ca";


### PR DESCRIPTION
This should simplify Front End Logic for signed transaction destinations.