### PR TITLE
Uniswap V3 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@safe-global/safe-gateway-typescript-sdk": "^3.22.6",
     "near-api-js": "^5.0.1",
-    "near-ca": "^0.8.1",
+    "near-ca": "^0.8.2",
     "semver": "^7.6.3",
     "viem": "^2.22.8"
   },

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -475,7 +475,7 @@ export class NearSafe {
     const lowerMpc = this.mpcAddress.toLowerCase();
     // We allow zeroAddress (and and treat is as from = safe)
     if (![lowerSafe, lowerMpc, lowerZero].includes(lowerFrom)) {
-      throw new Error(`Unexpected from address ${from}`);
+      throw new Error(`Unexpected from address ${from} - expected {}`);
     }
     return [this.address.toLowerCase(), lowerZero].includes(lowerFrom);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,11 +18,8 @@ import {
   toBytes,
   keccak256,
   serializeSignature,
-  createPublicClient,
-  http,
 } from "viem";
 
-import { DEFAULT_SETUP_RPC } from "./constants";
 import { PaymasterData, MetaTransaction, UserOperation } from "./types";
 
 export const PLACEHOLDER_SIG = encodePacked(["uint48", "uint48"], [0, 0]);
@@ -67,12 +64,10 @@ export async function isContract(
   return (await getClient(chainId).getCode({ address })) !== undefined;
 }
 
-export function getClient(chainId: number): PublicClient {
-  // TODO(bh2smith): Update defailt client URL in viem for sepolia.
-  if (chainId === 11155111) {
-    return createPublicClient({ transport: http(DEFAULT_SETUP_RPC) });
-  }
-  return Network.fromChainId(chainId).client;
+export function getClient(chainId: number, rpcUrl?: string): PublicClient {
+  // Caution: rpcUrl might not be aligned with chainId!
+  const options = rpcUrl? {rpcUrl}: {};
+  return Network.fromChainId(chainId, options).client;
 }
 
 export function metaTransactionsFromRequest(

--- a/src/util.ts
+++ b/src/util.ts
@@ -66,7 +66,7 @@ export async function isContract(
 
 export function getClient(chainId: number, rpcUrl?: string): PublicClient {
   // Caution: rpcUrl might not be aligned with chainId!
-  const options = rpcUrl? {rpcUrl}: {};
+  const options = rpcUrl ? { rpcUrl } : {};
   return Network.fromChainId(chainId, options).client;
 }
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import { isHex } from "viem";
+import { isHex, zeroAddress } from "viem";
 
 import { DEFAULT_SAFE_SALT_NONCE, NearSafe } from "../src";
 import { decodeTxData } from "../src/decode";
@@ -92,6 +92,23 @@ describe("Near Safe Requests", () => {
         "0x5c395ac0d1ccc0727918d636e8faca7eec2758cc9928c8a8d96e4f58aba453c5",
       evmMessage: typedDataString,
     });
+  });
+
+  it("adapter: encodeEvmTx Uniswap V3", async () => {
+    const chainId = 43114;
+    const request = await adapter.requestRouter({
+      method: "eth_signTypedData_v4",
+      params: [
+        zeroAddress,
+        // eslint-disable-next-line quotes
+        '{"types":{"PermitSingle":[{"name":"details","type":"PermitDetails"},{"name":"spender","type":"address"},{"name":"sigDeadline","type":"uint256"}],"PermitDetails":[{"name":"token","type":"address"},{"name":"amount","type":"uint160"},{"name":"expiration","type":"uint48"},{"name":"nonce","type":"uint48"}],"EIP712Domain":[{"name":"name","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}]},"domain":{"name":"Permit2","chainId": 43114,"verifyingContract":"0x000000000022d473030f116ddee9f6b43ac78ba3"},"primaryType":"PermitSingle","message":{"details":{"token":"0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e","amount":"1461501637330902918203684832716283019655932542975","expiration":"1739457501","nonce":"0"},"spender":"0x4dae2f939acf50408e13d58534ff8c2776d45265","sigDeadline":"1736867301"}}',
+      ],
+      chainId,
+    });
+    console.log(request);
+    expect(() =>
+      decodeTxData({ evmMessage: request.evmMessage, chainId })
+    ).not.toThrow();
   });
 
   it("adapter: requestRouter", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4257,10 +4257,10 @@ near-api-js@^5.0.1:
     near-abi "0.1.1"
     node-fetch "2.6.7"
 
-near-ca@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.8.1.tgz#1157b27ffd8a782655017506c8896335b86da900"
-  integrity sha512-RHgnZU5duXnr2BwLnG/4uhaTWAt+UjbdHMvpA3b6Kfbl7VAcPH3REjro3MvaGAFPN9HH2RJcWKzQMg1z19NYFA==
+near-ca@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/near-ca/-/near-ca-0.8.2.tgz#c4797b7e02a0f6b4859245e209eb261cc0a360c0"
+  integrity sha512-tmQ7DBqRDJN4M6DSLGAXEQ77aF39lTpcpNz8O1FQuvDDAaTR8F+6/VPxjxNkE51KO+IvgwGnTR13xDHCJoLHxw==
   dependencies:
     "@walletconnect/web3wallet" "^1.13.0"
     elliptic "^6.5.6"


### PR DESCRIPTION
- allowing customizable rpcUrl for getClient (note that its not necessarily aligned by chainId)
- update near-ca 
  - moving rpc override internally - includes both sepolia that was here and avalanche
  - TypedDomain validation for chainId number strings
- add univ3 WC encoding test.