### PR TITLE
Fix Bundler Sponsorship Policy

### DIFF
--- a/src/lib/bundler.ts
+++ b/src/lib/bundler.ts
@@ -144,7 +144,7 @@ export class Erc4337Bundler {
   // New method to query sponsorship policies
   async getSponsorshipPolicies(): Promise<SponsorshipPolicyData[]> {
     const url = `https://api.pimlico.io/v2/account/sponsorship_policies?apikey=${this.apiKey}`;
-    const allPolocies = await handleRequest<SponsorshipPoliciesResponse>(
+    const allPolicies = await handleRequest<SponsorshipPoliciesResponse>(
       async () => {
         const response = await fetch(url);
 
@@ -156,9 +156,7 @@ export class Erc4337Bundler {
         return response.json();
       }
     );
-    return allPolocies.data.filter((p) =>
-      p.chain_ids.allowlist.includes(this.chainId)
-    );
+    return allPolicies.data;
   }
 }
 

--- a/src/lib/pimlico.ts
+++ b/src/lib/pimlico.ts
@@ -1,0 +1,93 @@
+import { HttpRequestError, RpcError } from "viem";
+
+import { SponsorshipPoliciesResponse, SponsorshipPolicyData } from "../types";
+
+export class Pimlico {
+  private apiKey: string;
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  bundlerUrl(chainId: number): string {
+    return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${this.apiKey}`;
+  }
+
+  // New method to query sponsorship policies
+  async getSponsorshipPolicies(): Promise<SponsorshipPolicyData[]> {
+    const url = `https://api.pimlico.io/v2/account/sponsorship_policies?apikey=${this.apiKey}`;
+    const allPolicies = await this.handleRequest<SponsorshipPoliciesResponse>(
+      async () => {
+        const response = await fetch(url);
+
+        if (!response.ok) {
+          throw new Error(
+            `HTTP error! status: ${response.status}: ${response.statusText}`
+          );
+        }
+        return response.json();
+      }
+    );
+    return allPolicies.data;
+  }
+
+  async getSponsorshipPolicyByName(
+    name: string
+  ): Promise<SponsorshipPolicyData> {
+    const allPolicies = await this.getSponsorshipPolicies();
+    const result = allPolicies.filter((t) => t.policy_name === name);
+    if (result.length === 0) {
+      throw new Error(
+        `No policy found with policy_name=${name}: try ${allPolicies.map((t) => t.policy_name)}`
+      );
+    } else if (result.length > 1) {
+      throw new Error(
+        `Multiple Policies with same policy_name=${name}: ${JSON.stringify(result)}`
+      );
+    }
+
+    return result[0]!;
+  }
+
+  async getSponsorshipPolicyById(id: string): Promise<SponsorshipPolicyData> {
+    const allPolicies = await this.getSponsorshipPolicies();
+    const result = allPolicies.filter((t) => t.id === id);
+    if (result.length === 0) {
+      throw new Error(
+        `No policy found with id=${id}: try ${allPolicies.map((t) => t.id)}`
+      );
+    }
+    // We assume that ids are unique so that result.length > 1 need not be handled.
+
+    return result[0]!;
+  }
+
+  async handleRequest<T>(clientMethod: () => Promise<T>): Promise<T> {
+    try {
+      return await clientMethod();
+    } catch (error) {
+      const message = stripApiKey(error);
+      if (error instanceof HttpRequestError) {
+        if (error.status === 401) {
+          throw new Error(
+            "Unauthorized request. Please check your Pimlico API key."
+          );
+        } else {
+          throw new Error(`Pimlico: ${message}`);
+        }
+      } else if (error instanceof RpcError) {
+        throw new Error(`Failed to send user op with: ${message}`);
+      }
+      throw new Error(`Bundler Request: ${message}`);
+    }
+  }
+}
+
+export function stripApiKey(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/(apikey=)[^\s&]+/, "$1***");
+  // Could also do this with slicing.
+  // const keyStart = message.indexOf("apikey=") + 7;
+  // // If no apikey in the message, return it as is.
+  // if (keyStart === -1) return message;
+  // return `${message.slice(0, keyStart)}***${message.slice(keyStart + 36)}`;
+}

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -480,11 +480,8 @@ export class NearSafe {
     return [this.address.toLowerCase(), lowerZero].includes(lowerFrom);
   }
 
-  async policyForChainId(chainId: number): Promise<SponsorshipPolicyData[]> {
-    // Chain ID doesn't matter for this bundler endpoint.
-    const anyBundler = this.bundlerForChainId(11155111);
-    const allPolicies = await anyBundler.getSponsorshipPolicies();
-    return allPolicies.filter((p) => p.chain_ids.allowlist.includes(chainId));
+  async policiesForChainId(chainId: number): Promise<SponsorshipPolicyData[]> {
+    return this.bundlerForChainId(chainId).getSponsorshipPolicies();
   }
 
   deploymentRequest(chainId: number): SignRequestData {

--- a/src/near-safe.ts
+++ b/src/near-safe.ts
@@ -481,8 +481,10 @@ export class NearSafe {
   }
 
   async policyForChainId(chainId: number): Promise<SponsorshipPolicyData[]> {
-    const bundler = this.bundlerForChainId(chainId);
-    return bundler.getSponsorshipPolicies();
+    // Chain ID doesn't matter for this bundler endpoint.
+    const anyBundler = this.bundlerForChainId(11155111);
+    const allPolicies = await anyBundler.getSponsorshipPolicies();
+    return allPolicies.filter((p) => p.chain_ids.allowlist.includes(chainId));
   }
 
   deploymentRequest(chainId: number): SignRequestData {

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -105,7 +105,6 @@ describe("Near Safe Requests", () => {
       ],
       chainId,
     });
-    console.log(request);
     expect(() =>
       decodeTxData({ evmMessage: request.evmMessage, chainId })
     ).not.toThrow();

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -3,6 +3,7 @@ import { isHex, zeroAddress } from "viem";
 
 import { DEFAULT_SAFE_SALT_NONCE, NearSafe } from "../src";
 import { decodeTxData } from "../src/decode";
+import { Pimlico } from "../src/lib/pimlico";
 
 dotenv.config();
 
@@ -58,8 +59,30 @@ describe("Near Safe Requests", () => {
     ).rejects.toThrow();
   });
 
-  it("bundler: getSponsorshipPolicy", async () => {
-    await expect(adapter.policyForChainId(100)).resolves.not.toThrow();
+  it("pimlico: getSponsorshipPolicies", async () => {
+    const pimlico = new Pimlico(process.env.PIMLICO_KEY!);
+    await expect(pimlico.getSponsorshipPolicies()).resolves.not.toThrow();
+    await expect(
+      pimlico.getSponsorshipPolicyByName("bitte-policy")
+    ).resolves.not.toThrow();
+  });
+
+  it("pimlico: getSponsorshipPolicies failures", async () => {
+    await expect(
+      new Pimlico("Invalid Key").getSponsorshipPolicies()
+    ).rejects.toThrow();
+
+    const pimlico = new Pimlico(process.env.PIMLICO_KEY!);
+    await expect(
+      pimlico.getSponsorshipPolicyByName("poop-policy")
+    ).rejects.toThrow("No policy found with policy_name=");
+    await expect(
+      pimlico.getSponsorshipPolicyById("invalid id")
+    ).rejects.toThrow("No policy found with id=");
+  });
+
+  it("bundler: policiesForChainId", async () => {
+    await expect(adapter.policiesForChainId(100)).resolves.not.toThrow();
   });
 
   it("adapter: encodeEvmTx", async () => {

--- a/tests/unit/lib/bundler.spec.ts
+++ b/tests/unit/lib/bundler.spec.ts
@@ -1,4 +1,5 @@
-import { Erc4337Bundler, stripApiKey } from "../../../src/lib/bundler";
+import { Erc4337Bundler } from "../../../src/lib/bundler";
+import { stripApiKey } from "../../../src/lib/pimlico";
 
 describe("Safe Pack", () => {
   const entryPoint = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";


### PR DESCRIPTION
Previously this was filtering by this.chainId which was really returning `policiesForChainId`. 
Note that this method is chain agnostic although the the chainId and entryPointAddress are required by the constructor. This hinted at somewhat bad design that could be improved.

We split the Transaction Bundler from the Pimlico Service so that users with a pimlico key can make those requests without having to specify all the other irrelevant details.

Tests Added.
